### PR TITLE
Ispravka greške u programu linijopolis

### DIFF
--- a/docs/takprog/2023_2024/okr/06_linijopolis.md
+++ b/docs/takprog/2023_2024/okr/06_linijopolis.md
@@ -136,7 +136,7 @@ hide:
 	struct autobus {
 	    int broj;
 	    long long bitovi;
-	} buff[MAXM];
+	};
 	
 	void ulaz() {
 	    scanf("%d %d", &M, &N);

--- a/docs/takprog/2023_2024/okr/06_linijopolis.md
+++ b/docs/takprog/2023_2024/okr/06_linijopolis.md
@@ -188,13 +188,13 @@ hide:
 	                preostalo = 0;
 	                najmanji.bitovi += uvecanje;
 	                najmanji.broj -= broj_dodatnih;
-	                busevi.push(najmanji);
 	                if (broj_dodatnih > 0) {
 	                    autobus novi;
 	                    novi.broj = broj_dodatnih;
 	                    novi.bitovi = najmanji.bitovi + 1;
 	                    busevi.push(novi);
 	                }
+	                busevi.push(najmanji);
 	            }
 	        }
 	        long long najmanje = busevi.top().bitovi;


### PR DESCRIPTION
## Opis Problema
U rešenju zadatka [Linijopolis](https://olympicode.rs/takprog/2023_2024/okr/06_linijopolis/) postoji greška zbog koje program prijavljuje za donji test primer rezultat 2 umesto 1.

```
2 2
3 3
1 8
7 1
```
## Ispravka Problema
U komitu ovog PR-a se nalazi ispravka greške, koja se sastoji od pomeranja iskaza na liniji 71 (`busevi.push(najmanji);`) iza `if` bloka koji počinje na liniji 72. Na ovaj način se zadržava invarijanta da vrh steka `busevi` uvek ukazuje na grupu autobusa sa najmanje bitova.

Takođe, niz `buff` je nepotreban pa je i on obrisan u sklopu ove ispravke.